### PR TITLE
migrate script dependencies to support Python 3.12

### DIFF
--- a/gt7telemetry.py
+++ b/gt7telemetry.py
@@ -4,8 +4,7 @@ from datetime import timedelta as td
 import socket
 import sys
 import struct
-# pip3 install salsa20
-from salsa20 import Salsa20_xor
+from Crypto.Cipher import Salsa20
 
 # ansi prefix
 pref = "\033["
@@ -51,7 +50,10 @@ def salsa20_dec(dat):
 	IV = bytearray()
 	IV.extend(iv2.to_bytes(4, 'little'))
 	IV.extend(iv1.to_bytes(4, 'little'))
-	ddata = Salsa20_xor(dat, bytes(IV), KEY[0:32])
+	
+	cipher = Salsa20.new(key=KEY[0:32], nonce=bytes(IV))
+	ddata = cipher.decrypt(dat)
+	
 	magic = int.from_bytes(ddata[0:4], byteorder='little')
 	if magic != 0x47375330:
 		return bytearray(b'')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pycryptodome==3.19.0
+gt-telem==1.1.1


### PR DESCRIPTION
Attempt to run scripts with Python 3.12 result in the error below

```
Traceback (most recent call last):
  File "/home/bman/Documents/dev/gt-fork/gt7telemetry-monitor/./gt7telemetry.py", line 8, in <module>
    from salsa20 import Salsa20_xor
  File "/home/bman/.local/share/virtualenvs/gt7telemetry-monitor-aRbyWjtk/lib/python3.12/site-packages/salsa20.py", line 11, in <module>
    import imp
ModuleNotFoundError: No module named 'imp'
```

The reason is that `imp` module was removed in 3.12 . Replaced script dependencies to alternative ones which do not have  such an issue